### PR TITLE
Convert to using http-client, removing conduit dependency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
++ Switch from http-conduit to http-client.
+
 # 0.5.2
 
 + Add convenience function for validating and compiling draft 4 schemas

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -32,7 +32,7 @@ library
                       , file-embed           >= 0.0.8 && < 0.0.9
                       , hashable             >= 1.2   && < 1.3
                       , hjsonpointer         >= 0.1   && < 0.2
-                      , http-conduit         >= 2.1.5 && < 2.2
+                      , http-client          >= 0.4.9 && < 0.5
                       , http-types           >= 0.8   && < 0.9
                       , regexpr              >= 0.5   && < 0.6
                       , scientific           >= 0.3   && < 0.4

--- a/src/Data/JsonSchema/Reference.hs
+++ b/src/Data/JsonSchema/Reference.hs
@@ -13,7 +13,7 @@ import qualified Data.HashMap.Strict  as H
 import           Data.Monoid
 import           Data.Text            (Text)
 import qualified Data.Text            as T
-import           Network.HTTP.Conduit
+import           Network.HTTP.Client
 import           Prelude              hiding (foldr)
 
 combineIdAndRef :: Text -> Text -> Text
@@ -61,3 +61,5 @@ safeGet url =
   where
     handler :: SomeException -> IO (Either Text ByteString)
     handler e = return . Left . T.pack . show $ e
+    simpleHttp u = withManager defaultManagerSettings $ \man ->
+      parseUrl u >>= \req -> liftM responseBody $ httpLbs req {requestHeaders = ("Connection", "close") : requestHeaders req } man


### PR DESCRIPTION
Conduit can be a heavyweight dependency to carry around just to make a
simple (aka non-streaming) http request.  Change over to using
http-client, which underpins http-conduit _anyway_, shaving off some
transitive dependencies.
