### PR TITLE
Auto testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ ghc:
 before_install:
   - cabal install alex happy
 
-notifications:
-  email:
-    - mdorman@jaunder.io
-
 script:
   - cabal configure --enable-tests
   - cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: haskell
+
+ghc:
+  - 7.6
+  - 7.8
+
+before_install:
+  - cabal install alex happy
+
+notifications:
+  email:
+    - mdorman@jaunder.io
+
+script:
+  - cabal configure --enable-tests
+  - cabal test
+  - cabal check
+  - cabal sdist
+
+  # check that the generated source-distribution can be built & installed
+  - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
+    cd dist/;
+    if [ -f "$SRC_TGZ" ]; then
+      cabal install "$SRC_TGZ";
+    else
+       echo "expected '$SRC_TGZ' not found";
+       exit 1;
+    fi

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ fromList ["Val error against uniqueItems True for: Array (fromList [String \"foo
 
     git submodule update --init
 
-# Prepare Tests
-
-+ `cd JSON-Schema-Test-Suite/remotes`
-
-+ `hserv --port=1234` / `python -m SimpleHTTPServer 1234`
-
-Note that the `remote` test suite requires an internet connection.
-
 # Notes
 
 + This uses the [regexpr](https://hackage.haskell.org/package/regexpr-0.5.4) regular expression library for the "pattern" validator. I have no idea if this is compatible with the ECMA 262 regex dialect, which the [spec](http://json-schema.org/latest/json-schema-validation.html#anchor33) requires.

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -1,6 +1,7 @@
 name:                   hjsonschema
 version:                0.5.3.1
 synopsis:               JSON Schema Draft 4 library
+description:            Check your Aeson structures against json-schema descriptions
 homepage:               https://github.com/seagreen/hjsonschema
 license:                MIT
 license-file:           MIT-LICENSE.txt

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -70,6 +70,7 @@ test-suite remote
   default-extensions:   OverloadedStrings
   other-extensions:     TemplateHaskell
   build-depends:        aeson
+                      , async
                       , base
                       , bytestring
                       , hjsonschema
@@ -81,6 +82,8 @@ test-suite remote
                       , HUnit                >= 1.2 && < 1.3
                       , test-framework       >= 0.8 && < 0.9
                       , test-framework-hunit >= 0.3 && < 0.4
+                      , wai-app-static
+                      , warp
 
 source-repository head
   type:               git

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -26,8 +26,8 @@ library
   default-extensions:   OverloadedStrings
   other-extensions:     TemplateHaskell
   ghc-options:          -Wall
-  build-depends:        aeson                >= 0.8   && < 0.9
-                      , base                 >= 4.7   && < 4.9
+  build-depends:        aeson                >= 0.7   && < 0.9
+                      , base                 >= 4.6   && < 4.9
                       , bytestring           >= 0.10  && < 0.11
                       , file-embed           >= 0.0.8 && < 0.0.9
                       , hashable             >= 1.2   && < 1.3

--- a/tests/Remote.hs
+++ b/tests/Remote.hs
@@ -1,17 +1,22 @@
 module Main where
 
 import           Control.Applicative
-import           Data.List           (isSuffixOf)
+import           Control.Concurrent.Async       (withAsync)
+import           Data.List                      (isSuffixOf)
 import           Lib
-import           System.Directory    (getDirectoryContents)
+import           Network.Wai.Application.Static (defaultFileServerSettings,
+                                                 staticApp)
+import           Network.Wai.Handler.Warp       (run)
+import           System.Directory               (getDirectoryContents)
 import           Test.Framework
 
 main :: IO ()
-main = do
-  filenames <- filter (not . isLocal) . filter (".json" `isSuffixOf`)
+main =
+  withAsync (run 1234 $ staticApp $ defaultFileServerSettings "JSON-Schema-Test-Suite/remotes") $ \_ -> do
+    filenames <- filter (not . isLocal) . filter (".json" `isSuffixOf`)
                  <$> getDirectoryContents dir
-  ts <- readSchemaTests dir filenames
-  defaultMain (toTest <$> ts)
+    ts <- readSchemaTests dir filenames
+    defaultMain (toTest <$> ts)
 
   where
     dir :: String


### PR DESCRIPTION
Now that hjsonpointer has relaxed lower bounds (thanks for doing that so quickly!) I believe hjsonschema can have similarly relaxed bounds.

In order to make that testable using travis (and because I was re-reading Parallel and Concurrent Haskell), I added code to the remote test to fire up a static file server on a thread, removing the need for an external server.
