### PR TITLE
Include missing example file

### DIFF
--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -16,6 +16,7 @@ extra-source-files:     changelog.txt
                         README.md
                         src/draft4.json
                         test/Local/*.json
+                        examples/json/*.json
 
 library
   hs-source-dirs:       src


### PR DESCRIPTION
Without this file---which doesn't get included into the hackage release---two tests break.
