### PR TITLE
Add support for fetching schemas from `https` URLs

### DIFF
--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -69,6 +69,7 @@ library
     , hjsonpointer         >= 1.1
     -- 0.4.30 is for parseUrlThrow:
     , http-client          >= 0.4.30
+    , http-client-tls      >= 0.3
     , http-types           >= 0.8
     , pcre-heavy           >= 1.0
     , profunctors          >= 5.0

--- a/src/JSONSchema/Fetch.hs
+++ b/src/JSONSchema/Fetch.hs
@@ -9,6 +9,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Network.HTTP.Client as NC
+import qualified Network.HTTP.Client.TLS as NCTLS
 
 import           JSONSchema.Validator.Reference (BaseURI(..), resolveReference,
                                                  updateResolutionScope)
@@ -59,7 +60,7 @@ referencesViaHTTP'
     -> SchemaWithURI schema
     -> IO (Either HTTPFailure (URISchemaMap schema))
 referencesViaHTTP' info sw = do
-    manager <- NC.newManager NC.defaultManagerSettings
+    manager <- NC.newManager NCTLS.tlsManagerSettings
     let f = referencesMethodAgnostic (getURL manager) info sw
     catch (first HTTPParseFailure <$> f) handler
   where


### PR DESCRIPTION
This pull request adds support for TLS which allows validating schemas referenced via `https`.

Let me know if there is anything else you'd like to see here.