### PR TITLE
Add GHC-8.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-8.2.1"
+    - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ matrix:
     - compiler: "ghc-8.2.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.2.2], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.4.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.4.1], sources: [hvr-ghc]}}
 
 before_install:
  - HC=${CC}

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -81,6 +81,8 @@ library
     , unordered-containers >= 0.2
     , text                 >= 1.1
     , vector               >= 0.10
+  if impl(ghc < 8.0)
+    build-depends: semigroups == 0.18.*
 
 test-suite local
   hs-source-dirs:

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -10,7 +10,7 @@ category:           Data
 build-type:         Simple
 cabal-version:      >=1.10
 -- Rerun multi-ghc-travis (executable make-travis-yml-2) after changing:
-Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.1
+Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2
 extra-source-files:
   changelog.md
   JSON-Schema-Test-Suite/remotes/*.json

--- a/hjsonschema.cabal
+++ b/hjsonschema.cabal
@@ -10,7 +10,7 @@ category:           Data
 build-type:         Simple
 cabal-version:      >=1.10
 -- Rerun multi-ghc-travis (executable make-travis-yml-2) after changing:
-Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2
+Tested-With:        GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.1
 extra-source-files:
   changelog.md
   JSON-Schema-Test-Suite/remotes/*.json

--- a/src/JSONSchema/Fetch.hs
+++ b/src/JSONSchema/Fetch.hs
@@ -7,6 +7,7 @@ import           Control.Monad (foldM)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Semigroup as S
 import qualified Data.Text as T
 import qualified Network.HTTP.Client as NC
 import qualified Network.HTTP.Client.TLS as NCTLS
@@ -29,7 +30,7 @@ data FetchInfo schema = FetchInfo
 -- | Keys are URIs (without URI fragments).
 newtype URISchemaMap schema
     = URISchemaMap { _unURISchemaMap :: HashMap Text schema }
-    deriving (Eq, Show, Monoid)
+    deriving (Eq, Show, S.Semigroup, Monoid)
 
 -- | A top-level schema along with its location.
 data SchemaWithURI schema = SchemaWithURI


### PR DESCRIPTION
- Add GHC 8.4 support, see https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#base-4.11.0.0
- Update Travis GHC version to 8.2.2
- Add Travis GHC 8.4.1 build
  It's failing due to hjsonpointer dependency, which is fixed in https://github.com/seagreen/hjsonpointer/pull/4